### PR TITLE
Invocation.build renamed to Invocation.reflect

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Extract information about a method's invocation including the method name, param
 ``` ruby
 class Example
   def some_method(some_parameter, some_other_parameter)
-    Invocation.build(binding)
+    Invocation.reflect(binding)
   end
 end
 
@@ -30,7 +30,7 @@ A method signature with positional parameters, named parameters, splat parameter
 
 ``` ruby
 def some_method(some_parameter, *parameters, some_other_parameter:, **named_parameters, &blk)
-  ::Invocation.build(binding)
+  ::Invocation.reflect(binding)
 end
 ```
 

--- a/lib/invocation/controls/mixed_parameters.rb
+++ b/lib/invocation/controls/mixed_parameters.rb
@@ -16,7 +16,7 @@ class Invocation
           **some_multiple_assignment_keyword_parameter,
           &some_block
         )
-          ::Invocation.build(binding)
+          ::Invocation.reflect(binding)
         end
       end
     end

--- a/lib/invocation/controls/no_parameters.rb
+++ b/lib/invocation/controls/no_parameters.rb
@@ -8,7 +8,7 @@ class Invocation
 
       class Example
         def some_method
-          ::Invocation.build(binding)
+          ::Invocation.reflect(binding)
         end
       end
     end

--- a/lib/invocation/invocation.rb
+++ b/lib/invocation/invocation.rb
@@ -7,7 +7,7 @@ class Invocation
     @arguments = arguments
   end
 
-  def self.build(bndg)
+  def self.reflect(bndg)
     instance = bndg.receiver
     method_name = bndg.eval("__method__")
 


### PR DESCRIPTION
Resolves #1 (Rename build constructor to reflect)

# Background

Invocation's constructor is named `.build`, but it should have been named `.reflect`.

# Current Behavior

```
def some_method(some_parameter, some_other_parameter)
  Invocation.build(binding)
end
```

# Proposed Change

```
def some_method(some_parameter, some_other_parameter)
  Invocation.reflect(binding)
end
```

# Dependent gems

There are two Eventide libraries that reference `Invocation.build`, `mimic` and `record-invocation`. Pull requests that update those references to `Invocation.reflect` have been submitted:

- mimic gem [PR#12](https://github.com/eventide-project/mimic/pull/12)
- record-invocation gem [PR#3](https://github.com/eventide-project/record-invocation/pull/3)

